### PR TITLE
Feature/mat/ci

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -124,6 +124,7 @@
 								</option>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths.727679617" name="Include paths (-I)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includepaths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="../Inc"/>
+									<listOptionValue builtIn="false" value="../note-c"/>
 									<listOptionValue builtIn="false" value="../Drivers/CMSIS/Include"/>
 									<listOptionValue builtIn="false" value="../Drivers/STM32L0xx_HAL_Driver/Inc"/>
 									<listOptionValue builtIn="false" value="../Drivers/CMSIS/Device/ST/STM32L0xx/Include"/>

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+on: [push, pull_request]
+
+jobs:
+  stm32_ci_job:
+    runs-on: ubuntu-latest
+    name: CI job for stm32
+    steps:
+    - uses: actions/checkout@v2
+    - name: CI action step for stm32
+      id: stm32ci
+      uses: milesfrain/stm32-action@v0.5
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     name: CI job for stm32
     steps:
-    - uses: actions/checkout@v2
+    - name: checkout code
+      uses: actions/checkout@v2
     - name: CI action step for stm32
       id: stm32ci
       uses: milesfrain/stm32-action@v0.5

--- a/ci.sh
+++ b/ci.sh
@@ -12,6 +12,6 @@ STM32CUBEIDE_BUILD_TARGET=${STM32CUBEIDE_BUILD_TARGET:-all}
 
 # Run build
 # MDM: I had to remove the `-data .` parameter before import for the build to begin. 
-${STM32CUBEIDE_PATH}/stm32cubeide --launcher.suppressErrors -nosplash -application org.eclipse.cdt.managedbuilder.core.headlessbuild  -import . -build ${STM32CUBEIDE_BUILD_TARGET} -no-indexer
+${STM32CUBEIDE_PATH}/stm32cubeide --launcher.suppressErrors -nosplash -application org.eclipse.cdt.managedbuilder.core.headlessbuild  -import . -cleanBuild ${STM32CUBEIDE_BUILD_TARGET} -no-indexer
 build_ret=$?
 exit $build_ret

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# echo commands
+set -x
+
+STM32CUBEIDE_BUILD_TARGET=Debug
+
+
+# This is generic (so why not put in the docker image?)
+
+STM32CUBEIDE_PATH=${STM32CUBEIDE_PATH:-/opt/st/stm32cubeide_1.4.0}
+STM32CUBEIDE_BUILD_TARGET=${STM32CUBEIDE_BUILD_TARGET:-all}
+
+# Run build
+# MDM: I had to remove the `-data .` parameter before import for the build to begin. 
+${STM32CUBEIDE_PATH}/stm32cubeide --launcher.suppressErrors -nosplash -application org.eclipse.cdt.managedbuilder.core.headlessbuild  -import . -build ${STM32CUBEIDE_BUILD_TARGET} -no-indexer
+build_ret=$?
+exit $build_ret

--- a/ci.sh
+++ b/ci.sh
@@ -3,7 +3,6 @@
 # echo commands
 set -x
 
-STM32CUBEIDE_BUILD_TARGET=Debug
 
 
 # This is generic (so why not put in the docker image?)


### PR DESCRIPTION
Adds CI build using headless invocation of STM32CubeIDE.  Builds all configurations in the project - Debug and Release.

WiP/PoC for review and incremental adjustment.

Some improvements:

* presently using a docker image based on STM32CubeIDE 1.4.0.  More recent versions are available, such as this one, https://github.com/xanderhendriks/docker-stm32cubeide

* The repo presently includes the output build directory `Debug`.  We can move these to github releases.  Automated release builds via an action that creates a release when a tagged build is done performed.